### PR TITLE
Equipping Optimization

### DIFF
--- a/BodyPartController.cs
+++ b/BodyPartController.cs
@@ -83,13 +83,13 @@ namespace BlacksmithTools
 
                         for (int bone = 0; bone < 4; bone++)
                         {
-                            int boneIndex = (int)typeof(BoneWeight).GetProperty("boneIndex" + bone).GetValue(weight);
+                            int boneIndex = GetBoneIndex(weight, bone);
                             foreach (int boneToHide in bonesToHide)
                             {
                                 if (toHide) break;
 
                                 if (boneIndex != boneToHide) continue;
-                                float value = (float)typeof(BoneWeight).GetProperty("weight" + bone).GetValue(weight);
+                                float value = GetBoneWeight(weight, bone);
                                 if ((value / highestWeight) > minWeightToHide)
                                 {
                                     if (++detectedVerts == vertexThreshold)
@@ -118,6 +118,24 @@ namespace BlacksmithTools
             }
 
             return body;
+        }
+
+        int GetBoneIndex(BoneWeight boneWeight, int bone)
+        {
+            if (bone == 0) return boneWeight.boneIndex0;
+            if (bone == 1) return boneWeight.boneIndex1;
+            if (bone == 2) return boneWeight.boneIndex2;
+            if (bone == 3) return boneWeight.boneIndex3;
+            return -1;
+        }
+
+        float GetBoneWeight(BoneWeight boneWeight, int bone)
+        {
+            if (bone == 0) return boneWeight.weight0;
+            if (bone == 1) return boneWeight.weight1;
+            if (bone == 2) return boneWeight.weight2;
+            if (bone == 3) return boneWeight.weight3;
+            return 0f;
         }
 
         public void Setup(VisEquipment _viseq)

--- a/BodyPartController.cs
+++ b/BodyPartController.cs
@@ -79,17 +79,10 @@ namespace BlacksmithTools
                         if (toHide) break;
 
                         BoneWeight weight = weights[tris[tri + vert]];
+                        float highestWeight = Mathf.Max(weight.weight0, weight.weight1, weight.weight2, weight.weight3);
+
                         for (int bone = 0; bone < 4; bone++)
                         {
-                            float[] vertexWeights = new float[]
-                            {
-                            weight.weight0,
-                            weight.weight1,
-                            weight.weight2,
-                            weight.weight3
-                            };
-                            float highestWeight = vertexWeights.Max();
-
                             int boneIndex = (int)typeof(BoneWeight).GetProperty("boneIndex" + bone).GetValue(weight);
                             foreach (int boneToHide in bonesToHide)
                             {


### PR DESCRIPTION
There is a slight stutter when equipping/un-equipping equipment that is doing a `FullUpdate`. On my computer it was around 150-200ms per `FullUpdate`, which is already noticeable. If you press R to equip the last layout and there are two equipments, this could cause a stutter for nearly half a second.

This PR replaces heavy Reflection code with direct access to the BoneWeight struct. The changes improve the execution time significantly and are almost undetectable now. Even with multiple `FullUpdate` calls, the time never exceeded 10ms in my profiling session.